### PR TITLE
adding datagram and i2cp options to SessionOptions

### DIFF
--- a/src/asynchronous/session/style/datagram.rs
+++ b/src/asynchronous/session/style/datagram.rs
@@ -71,26 +71,6 @@ impl Repliable {
             .map_err(From::from)
     }
 
-    pub(crate) async fn _send_to_with_options(
-        &mut self,
-        buf: &[u8],
-        destination: &str,
-    ) -> crate::Result<()> {
-        let mut datagram = format!(
-            "3.0 {} {} {} {}\n",
-            self.options.nickname, destination, self.options.from_port, self.options.to_port
-        )
-        .as_bytes()
-        .to_vec();
-        datagram.extend_from_slice(buf);
-
-        self.socket
-            .send_to(&datagram, &self.server_address)
-            .await
-            .map(|_| ())
-            .map_err(From::from)
-    }
-
     pub(crate) async fn recv_from(&mut self, buf: &mut [u8]) -> crate::Result<(usize, String)> {
         let nread = self.socket.recv(&mut self.buffer).await?;
 
@@ -121,7 +101,7 @@ impl private::SessionStyle for Repliable {
         Self: Sized,
     {
         async {
-            let socket = UdpSocket::bind(format!("127.0.0.1:{}", 0u16)).await?;
+            let socket = UdpSocket::bind(format!("127.0.0.1:{}", options.datagram_port)).await?;
             let stream = BufReader::new(
                 TcpStream::connect(format!("127.0.0.1:{}", options.samv3_tcp_port)).await?,
             );
@@ -180,7 +160,7 @@ impl private::Subsession for Repliable {
         Self: Sized,
     {
         async {
-            let socket = UdpSocket::bind(format!("127.0.0.1:{}", 0u16)).await?;
+            let socket = UdpSocket::bind(format!("127.0.0.1:{}", options.datagram_port)).await?;
             let server_address =
                 format!("127.0.0.1:{}", options.samv3_udp_port).parse().expect("to succeed");
 
@@ -227,31 +207,6 @@ impl Anonymous {
             .map_err(From::from)
     }
 
-    pub(crate) async fn _send_to_with_options(
-        &mut self,
-        buf: &[u8],
-        destination: &str,
-    ) -> crate::Result<()> {
-        let mut datagram = format!(
-            "3.0 {} {} {} {} {} {}\n",
-            self.options.nickname,
-            destination,
-            self.options.from_port,
-            self.options.to_port,
-            self.options.protocol,
-            self.options.header
-        )
-        .as_bytes()
-        .to_vec();
-        datagram.extend_from_slice(buf);
-
-        self.socket
-            .send_to(&datagram, &self.server_address)
-            .await
-            .map(|_| ())
-            .map_err(From::from)
-    }
-
     pub(crate) async fn recv(&mut self, buf: &mut [u8]) -> crate::Result<usize> {
         self.socket.recv(buf).await.map_err(From::from)
     }
@@ -263,7 +218,7 @@ impl private::SessionStyle for Anonymous {
         Self: Sized,
     {
         async {
-            let socket = UdpSocket::bind(format!("127.0.0.1:{}", 0u16)).await?;
+            let socket = UdpSocket::bind(format!("127.0.0.1:{}", options.datagram_port)).await?;
             let stream = BufReader::new(
                 TcpStream::connect(format!("127.0.0.1:{}", options.samv3_tcp_port)).await?,
             );
@@ -322,7 +277,7 @@ impl private::Subsession for Anonymous {
         Self: Sized,
     {
         async {
-            let socket = UdpSocket::bind(format!("127.0.0.1:{}", 0u16)).await?;
+            let socket = UdpSocket::bind(format!("127.0.0.1:{}", options.datagram_port)).await?;
             let server_address =
                 format!("127.0.0.1:{}", options.samv3_udp_port).parse().expect("to succeed");
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -90,7 +90,40 @@ pub struct SessionOptions {
     /// Defaults to `false`.
     pub header: bool,
 
-    pub i2cp_options: I2CPOptions,
+    /// How many hops do the inbound tunnels of the session have.
+    ///
+    /// Defaults to `3`.
+    pub inbound_len: usize,
+
+    /// How many inbound tunnels does the tunnel pool of the session have.
+    ///
+    /// Defaults to `2`.
+    pub inbound_qty: usize,
+
+    /// How many hops do the outbound tunnels of the session have.
+    ///
+    /// Defaults to `3`.
+    pub outbound_len: usize,
+
+    /// How many outbound tunnels does the tunnel pool of the session have.
+    ///
+    /// Defaults to `2`.
+    pub outbound_qty: usize,
+
+    /// Should the session's lease set be published to NetDb.
+    ///
+    /// Outbound-only sessions (clients) shouldn't be published whereas servers (accepting inbound
+    /// connections) need to be published.
+    /// 
+    /// Corresponds to `i2cp.dontPublishLeaseSet`.
+    ///
+    /// Defaults to `true`.
+    pub publish_lease_set: bool,
+
+    /// Other options related to I2P Client Protocol
+    /// 
+    /// Defaults to 'None'
+    pub other_i2cp_options: Option<OtherI2CPOptions>,
 
     /// TCP port of the listening SAMv3 server.
     ///
@@ -122,7 +155,12 @@ impl Default for SessionOptions {
             to_port: 0u16,
             protocol: 18u8,
             header: false,
-            i2cp_options: I2CPOptions::default(),
+            inbound_len: 3usize,
+            inbound_qty: 2usize,
+            outbound_len: 3usize,
+            outbound_qty: 2usize,
+            publish_lease_set: true,
+            other_i2cp_options: None,
             samv3_tcp_port: SAMV3_TCP_PORT,
             samv3_udp_port: SAMV3_UDP_PORT,
             silent_forward: false,
@@ -131,97 +169,46 @@ impl Default for SessionOptions {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct I2CPOptions {
+pub struct OtherI2CPOptions {
     /// Minimum number of ElGamal/AES Session Tags before we send more. Recommended: approximately
     /// tagsToSend * 2/3
-    ///
-    /// Defaults to '0'
     pub crypto_low_tag_threshold: usize,
     /// Inbound tag window for ECIES-X25519-AEAD-Ratchet. Local inbound tagset size.
-    ///
-    /// Defaults to '0'
     pub crypto_ratchet_inbound_tags: usize,
     /// Outbound tag window for ECIES-X25519-AEAD-Ratchet. Advisory to send to the far-end in the
     /// options block.
-    ///
-    /// Defaults to '0'
     pub crypto_ratchet_outbound_tags: usize,
     /// Number of ElGamal/AES Session Tags to send at a time.
-    ///
-    /// Defaults to '0'
     pub crypto_tags_to_send: usize,
-    /// Should the session's lease set be published to NetDb.
-    ///
-    /// Outbound-only sessions (clients) shouldn't be published whereas servers (accepting inbound
-    /// connections) need to be published.
-    ///
-    /// Defaults to `true`.
-    pub publish_lease_set: bool,
     /// If true, the router just sends the MessagePayload instead of sending a MessageStatus and
     /// awaiting a ReceiveMessageBegin.
-    ///
-    /// Defaults to 'false'
     pub fast_receive: bool,
     /// For authorization, if required by the router.
     pub username: Option<String>,
     /// For authorization, if required by the router.
     pub password: Option<String>,
     /// If incoming zero hop tunnel is allowed
-    ///
-    /// Defaults to 'false'
     pub inbound_allow_zero_hop: bool,
     /// Number of redundant fail-over for tunnels in
-    ///
-    /// Defaults to '0'
     pub inbound_backup_qty: usize,
     /// Number of IP bytes to match to determine if two routers should not be in the same tunnel. 0
     /// to disable.
-    ///
-    /// Defaults to '0'
     pub inbound_ip_restriction: usize,
-    /// How many hops do the inbound tunnels of the session have.
-    ///
-    /// Defaults to `3`.
-    pub inbound_len: usize,
     /// Random amount to add or subtract to the length of tunnels in.
-    ///
-    /// Defaults to '0'
     pub inbound_len_variance: isize,
-    /// How many inbound tunnels does the tunnel pool of the session have.
-    ///
-    /// Defaults to `2`.
-    pub inbound_qty: usize,
     /// Used for consistent peer ordering across restarts.
     pub inbound_random_key: Option<String>,
     /// If outgoing zero hop tunnel is allowed
-    ///
-    /// Defaults to 'false'
     pub outbound_allow_zero_hop: bool,
     /// Number of redundant fail-over for tunnels out
-    ///
-    /// Defaults to '0'
     pub outbound_backup_qty: usize,
     /// Number of IP bytes to match to determine if two routers should not be in the same tunnel. 0
     /// to disable.
-    ///
-    /// Defaults to '0'
     pub outbound_ip_restriction: usize,
     /// Priority adjustment for outbound messages. Higher is higher priority.
-    ///
-    /// Defaults to '0'
     pub outbound_priority: isize,
-    /// How many hops do the outbound tunnels of the session have.
-    ///
-    /// Defaults to `3`.
-    pub outbound_len: usize,
     /// Random amount to add or subtract to the length of tunnels in.
-    ///
-    /// Defaults to '0'
     pub outbound_len_variance: isize,
-    /// How many outbound tunnels does the tunnel pool of the session have.
-    ///
-    /// Defaults to `2`.
-    pub outbound_qty: usize,
     /// Used for consistent peer ordering across restarts.
     pub outbound_random_key: Option<String>,
     /// Set to false to disable ever bundling a reply LeaseSet.
@@ -229,21 +216,13 @@ pub struct I2CPOptions {
     /// (ms) Idle time required
     pub close_idle_time: usize,
     /// Close I2P session when idle
-    ///
-    /// Defaults to 'false'
     pub close_on_idle: bool,
     /// Encrypt the lease
-    /// 
-    /// Defaults to 'false'
     pub encrypt_lease_set: bool,
     /// Gzip outbound data
-    /// 
-    /// Defaults to 'true'
     pub gzip: bool,
     /// The type of authentication for encrypted LS2. 0 for no per-client authentication ;
     /// 1 for DH per-client authentication; 2 for PSK per-client authentication.
-    ///
-    /// Defaults to '0'
     pub lease_set_auth_type: usize,
     /// The sig type of the blinded key for encrypted LS2. Default depends on the destination sig
     /// type.
@@ -263,61 +242,11 @@ pub struct I2CPOptions {
     /// (ms) Idle time required
     pub reduce_idle_time: usize,
     /// Reduce tunnel quantity when idle
-    ///
-    /// Defaults to 'false'
     pub reduce_on_idle: bool,
     /// Tunnel quantity when reduced (applies to both inbound and outbound)
     pub reduce_quantity: usize,
     /// Connect to the router using SSL.
-    ///
-    /// Defaults to 'false'
     pub ssl: bool,
-}
-
-impl Default for I2CPOptions {
-    fn default() -> Self {
-        Self {
-            crypto_low_tag_threshold: 0usize,
-            crypto_ratchet_inbound_tags: 0usize,
-            crypto_ratchet_outbound_tags: 0usize,
-            crypto_tags_to_send: 0usize,
-            publish_lease_set: true,
-            fast_receive: false,
-            username: None,
-            password: None,
-            inbound_allow_zero_hop: false,
-            inbound_backup_qty: 0usize,
-            inbound_ip_restriction: 0usize,
-            inbound_len: 3usize,
-            inbound_len_variance: 0isize,
-            inbound_qty: 2usize,
-            inbound_random_key: None,
-            outbound_allow_zero_hop: false,
-            outbound_backup_qty: 0usize,
-            outbound_ip_restriction: 0usize,
-            outbound_len: 3usize,
-            outbound_len_variance: 0isize,
-            outbound_priority: 0isize,
-            outbound_qty: 2usize,
-            outbound_random_key: None,
-            should_bundle_reply_info: true,
-            close_idle_time: 0usize,
-            close_on_idle: false,
-            encrypt_lease_set: false,
-            gzip: true,
-            lease_set_auth_type: 0usize,
-            lease_set_blinded_type: 0usize,
-            lease_set_enc_type: 4usize,
-            lease_set_key: None,
-            lease_set_private_key: None,
-            lease_set_secret: None,
-            lease_set_signing_private_key: None,
-            reduce_idle_time: 0usize,
-            reduce_on_idle: false,
-            reduce_quantity: 0usize,
-            ssl: false,
-        }
-    }
 }
 
 /// Stream options.

--- a/src/options.rs
+++ b/src/options.rs
@@ -69,12 +69,12 @@ pub struct SessionOptions {
     pub destination: DestinationKind,
 
     /// Signature type.
-    /// 
+    ///
     /// Default to '7' i.e. EdDSA_SHA512_Ed25519
     pub signature_type: u16,
 
     /// Port where the datagram socket should be bound to.
-    /// 
+    ///
     /// Defaults to `0`.
     pub datagram_port: u16,
 
@@ -102,23 +102,23 @@ pub struct SessionOptions {
 
     /// Minimum number of ElGamal/AES Session Tags before we send more. Recommended: approximately
     /// tagsToSend * 2/3
-    /// 
+    ///
     /// /// Defaults to `30`.
     pub crypto_low_tag_threshold: usize,
 
     /// Inbound tag window for ECIES-X25519-AEAD-Ratchet. Local inbound tagset size.
-    /// 
+    ///
     /// /// Defaults to `160`.
     pub crypto_ratchet_inbound_tags: usize,
 
     /// Outbound tag window for ECIES-X25519-AEAD-Ratchet. Advisory to send to the far-end in the
     /// options block.
-    /// 
+    ///
     /// /// Defaults to `160`.
     pub crypto_ratchet_outbound_tags: usize,
 
     /// Number of ElGamal/AES Session Tags to send at a time.
-    /// 
+    ///
     /// /// Defaults to `40`.
     pub crypto_tags_to_send: usize,
 
@@ -162,9 +162,9 @@ pub struct SessionOptions {
     /// Used for consistent peer ordering across restarts.
     pub inbound_random_key: Option<String>,
 
-    /// Name of inbound tunnels - generally used in routerconsole, which will use 
+    /// Name of inbound tunnels - generally used in routerconsole, which will use
     /// the first few characters of the Base64 hash of the destination by default.
-    /// 
+    ///
     /// Defauts to 'None'
     pub inbound_nickname: Option<String>,
 
@@ -208,7 +208,7 @@ pub struct SessionOptions {
     pub outbound_random_key: Option<String>,
 
     /// Name of outbound tunnels - generally ignored unless inbound.nickname is unset.
-    /// 
+    ///
     /// Defauts to 'None'
     pub outbound_nickname: Option<String>,
 

--- a/src/options.rs
+++ b/src/options.rs
@@ -98,7 +98,7 @@ pub struct SessionOptions {
     /// Corresponds to `i2cp.dontPublishLeaseSet`.
     ///
     /// Defaults to `true`.
-    pub publish_lease_set: bool,
+    pub publish: bool,
 
     /// Minimum number of ElGamal/AES Session Tags before we send more. Recommended: approximately
     /// tagsToSend * 2/3
@@ -312,7 +312,7 @@ impl Default for SessionOptions {
             to_port: 0u16,
             protocol: 18u8,
             header: false,
-            publish_lease_set: true,
+            publish: true,
             crypto_low_tag_threshold: 30usize,
             crypto_ratchet_inbound_tags: 160usize,
             crypto_ratchet_outbound_tags: 160usize,

--- a/src/options.rs
+++ b/src/options.rs
@@ -70,7 +70,7 @@ pub struct SessionOptions {
 
     /// Signature type.
     ///
-    /// Default to '7' i.e. EdDSA_SHA512_Ed25519
+    /// Default to `7`, i.e., EdDSA-SHA512-Ed25519
     pub signature_type: u16,
 
     /// Port where the datagram socket should be bound to.
@@ -103,34 +103,38 @@ pub struct SessionOptions {
     /// Minimum number of ElGamal/AES Session Tags before we send more. Recommended: approximately
     /// tagsToSend * 2/3
     ///
-    /// /// Defaults to `30`.
+    /// Defaults to `30`.
     pub crypto_low_tag_threshold: usize,
 
     /// Inbound tag window for ECIES-X25519-AEAD-Ratchet. Local inbound tagset size.
     ///
-    /// /// Defaults to `160`.
+    /// Defaults to `160`.
     pub crypto_ratchet_inbound_tags: usize,
 
     /// Outbound tag window for ECIES-X25519-AEAD-Ratchet. Advisory to send to the far-end in the
     /// options block.
     ///
-    /// /// Defaults to `160`.
+    /// Defaults to `160`.
     pub crypto_ratchet_outbound_tags: usize,
 
     /// Number of ElGamal/AES Session Tags to send at a time.
     ///
-    /// /// Defaults to `40`.
+    /// Defaults to `40`.
     pub crypto_tags_to_send: usize,
 
     /// For authorization, if required by the router.
+    ///
+    /// Defauts to `None`.
     pub username: Option<String>,
 
     /// For authorization, if required by the router.
+    ///
+    /// Defauts to `None`.
     pub password: Option<String>,
 
     /// If incoming zero hop tunnel is allowed
     ///
-    /// Defaults to 'false'
+    /// Defaults to `false`.
     pub inbound_allow_zero_hop: bool,
 
     /// How many hops do the inbound tunnels of the session have.
@@ -148,29 +152,31 @@ pub struct SessionOptions {
     /// Defaults to `2`.
     pub inbound_quantity: usize,
 
-    /// Number of redundant fail-over for tunnels in
+    /// Number of redundant, fail-over inbound tunnels
     ///
     /// Defaults to `0`.
-    pub inbound_backup_qty: usize,
+    pub inbound_backup_quantity: usize,
 
-    /// Number of IP bytes to match to determine if two routers should not be in the same tunnel. 0
-    /// to disable.
+    /// Number of IP bytes to match to determine if two routers should not be in the same inbound
+    /// tunnel.
     ///
-    /// Defaults to `0`.
-    pub inbound_ip_restriction: usize,
+    /// Defaults to `None`.
+    pub inbound_ip_restriction: Option<std::num::NonZeroUsize>,
 
     /// Used for consistent peer ordering across restarts.
+    ///
+    /// Defauts to `None`.
     pub inbound_random_key: Option<String>,
 
     /// Name of inbound tunnels - generally used in routerconsole, which will use
     /// the first few characters of the Base64 hash of the destination by default.
     ///
-    /// Defauts to 'None'
+    /// Defaults to `None`.
     pub inbound_nickname: Option<String>,
 
     /// If outgoing zero hop tunnel is allowed
     ///
-    ///  Defaults to 'false'
+    ///  Defaults to `false`.
     pub outbound_allow_zero_hop: bool,
 
     /// How many hops do the outbound tunnels of the session have.
@@ -188,54 +194,61 @@ pub struct SessionOptions {
     /// Defaults to `2`.
     pub outbound_quantity: usize,
 
-    /// Number of redundant fail-over for tunnels out
+    /// Number of redundant, fail-over outbound tunnels
     ///
     /// Defaults to `0`.
-    pub outbound_backup_qty: usize,
+    pub outbound_backup_quantity: usize,
 
-    /// Number of IP bytes to match to determine if two routers should not be in the same tunnel. 0
-    /// to disable.
+    /// Number of IP bytes to match to determine if two routers should not be in the same outbound
+    /// tunnel.
     ///
-    /// Defaults to `0`.
-    pub outbound_ip_restriction: usize,
+    /// Defaults to `None`.
+    pub outbound_ip_restriction: Option<std::num::NonZeroUsize>,
+
+    /// Used for consistent peer ordering across restarts.
+    ///
+    /// Defauts to `None`.
+    pub outbound_random_key: Option<String>,
+
+    /// Name of outbound tunnels - generally ignored unless `inbound_nickname` is unset.
+    ///
+    /// Defauts to `None`.
+    pub outbound_nickname: Option<String>,
 
     /// Priority adjustment for outbound messages. Higher is higher priority.
     ///
     /// Defaults to `0`.
     pub outbound_priority: isize,
 
-    /// Used for consistent peer ordering across restarts.
-    pub outbound_random_key: Option<String>,
-
-    /// Name of outbound tunnels - generally ignored unless inbound.nickname is unset.
-    ///
-    /// Defauts to 'None'
-    pub outbound_nickname: Option<String>,
-
     /// Set to false to disable ever bundling a reply LeaseSet.
     ///
     /// Defaults to `true`.
     pub should_bundle_reply_info: bool,
 
-    /// Close I2P session when idle
-    ///
-    /// Defaults to 'false'
-    pub close_on_idle: bool,
-
-    /// (ms) Idle time required before closing session
-    ///
-    /// Defaults to '1800000' ms (i.e. 30 minutes)
-    pub close_idle_time: Duration,
-
-    /// Encrypt the lease
+    /// Reduce tunnel quantity when idle
     ///
     /// Defaults to `false`.
-    pub encrypt_lease_set: bool,
+    pub reduce_on_idle: bool,
 
-    /// Gzip outbound data
+    /// Idle time required before reducing tunnel quantity
     ///
-    /// Defaults to `true`.
-    pub gzip: bool,
+    /// Defaults to 20 minutes.
+    pub reduce_idle_time: Duration,
+
+    /// Tunnel quantity when reduced (applies to both inbound and outbound)
+    ///
+    /// Defauts to `1`.
+    pub reduce_quantity: usize,
+
+    /// Close I2P session when idle
+    ///
+    /// Defaults to `false`.
+    pub close_on_idle: bool,
+
+    /// Idle time required before closing session
+    ///
+    /// Defaults to 30 minutes.
+    pub close_idle_time: Duration,
 
     /// The type of authentication for encrypted LS2. 0 for no per-client authentication ;
     /// 1 for DH per-client authentication; 2 for PSK per-client authentication.
@@ -251,35 +264,47 @@ pub struct SessionOptions {
 
     /// The encryption type to be used.
     ///
-    /// Defaults to '4' i.e. ECIES-X25519
+    /// Defaults to `4`, i.e., ECIES-X25519.
     pub lease_set_enc_type: usize,
 
     /// For encrypted leasesets. Base 64 SessionKey (44 characters)
+    ///
+    /// Defauts to `None`.
     pub lease_set_key: Option<String>,
 
     /// Base 64 private keys for encryption.
+    ///
+    /// Defauts to `None`.
     pub lease_set_private_key: Option<String>,
 
     /// Base 64 encoded UTF-8 secret used to blind the leaseset address.
+    ///
+    /// Defauts to `None`.
     pub lease_set_secret: Option<String>,
 
-    /// The type of leaseset to be sent in the CreateLeaseSet2 Message.
+    /// Base 64 private key for signatures.
+    ///
+    /// Defauts to `None`.
     pub lease_set_signing_private_key: Option<String>,
 
-    /// Reduce tunnel quantity when idle
+    /// The type of leaseset to be sent in the CreateLeaseSet2 Message.
     ///
-    /// Defaults to 'false'
-    pub reduce_on_idle: bool,
+    /// Defaults to `1`.
+    pub lease_set_type: usize,
 
-    /// (ms) Idle time required before reducing tunnel quantity
+    /// Encrypt the lease
     ///
-    /// Defaults to '1200000' ms (i.e. 20 minutes)
-    pub reduce_idle_time: Duration,
+    /// Defaults to `false`.
+    pub encrypt_lease_set: bool,
 
-    /// Tunnel quantity when reduced (applies to both inbound and outbound)
-    pub reduce_quantity: usize,
+    /// Gzip outbound data
+    ///
+    /// Defaults to `true`.
+    pub gzip: bool,
 
     /// Connect to the router using SSL.
+    ///
+    /// Defauts to `false`.
     pub ssl: bool,
 
     /// TCP port of the listening SAMv3 server.
@@ -323,24 +348,25 @@ impl Default for SessionOptions {
             inbound_len: 3usize,
             inbound_len_variance: 0isize,
             inbound_quantity: 2usize,
-            inbound_backup_qty: 0usize,
-            inbound_ip_restriction: 0usize,
+            inbound_backup_quantity: 0usize,
+            inbound_ip_restriction: None,
             inbound_random_key: None,
             inbound_nickname: None,
             outbound_allow_zero_hop: false,
             outbound_len: 3usize,
             outbound_len_variance: 0isize,
             outbound_quantity: 2usize,
-            outbound_backup_qty: 0usize,
-            outbound_ip_restriction: 0usize,
-            outbound_priority: 0isize,
+            outbound_backup_quantity: 0usize,
+            outbound_ip_restriction: None,
             outbound_random_key: None,
             outbound_nickname: None,
+            outbound_priority: 0isize,
             should_bundle_reply_info: true,
+            reduce_on_idle: false,
+            reduce_idle_time: Duration::from_millis(1200000),
+            reduce_quantity: 1usize,
             close_on_idle: false,
             close_idle_time: Duration::from_millis(1800000),
-            encrypt_lease_set: false,
-            gzip: true,
             lease_set_auth_type: 0usize,
             lease_set_blinded_type: 0usize,
             lease_set_enc_type: 4usize,
@@ -348,9 +374,9 @@ impl Default for SessionOptions {
             lease_set_private_key: None,
             lease_set_secret: None,
             lease_set_signing_private_key: None,
-            reduce_on_idle: false,
-            reduce_idle_time: Duration::from_millis(1200000),
-            reduce_quantity: 1usize,
+            lease_set_type: 1usize,
+            encrypt_lease_set: false,
+            gzip: true,
             ssl: false,
             samv3_tcp_port: SAMV3_TCP_PORT,
             samv3_udp_port: SAMV3_UDP_PORT,

--- a/src/proto/parser.rs
+++ b/src/proto/parser.rs
@@ -96,9 +96,9 @@ pub enum Response {
 impl<'a> TryFrom<ParsedCommand<'a>> for Response {
     type Error = ();
 
-    fn try_from(value: ParsedCommand<'a>) -> Result<Self, Self::Error> {
-        match (value.command, value.subcommand) {
-            ("HELLO", Some("REPLY")) => match value.key_value_pairs.get("VERSION") {
+    fn try_from(parsed_cmd: ParsedCommand<'a>) -> Result<Self, Self::Error> {
+        match (parsed_cmd.command, parsed_cmd.subcommand) {
+            ("HELLO", Some("REPLY")) => match parsed_cmd.key_value_pairs.get("VERSION") {
                 Some(version) => Ok(Response::Hello {
                     version: Ok(version.to_string()),
                 }),
@@ -106,27 +106,27 @@ impl<'a> TryFrom<ParsedCommand<'a>> for Response {
                     // if `VERSION` doesn't exist, `RESULT` is expected to exist as `NOVERSION`
                     // an unexpected error since reporting version is optional as of v3.1 and
                     // `yosemite` doesn't send a version string to the router
-                    let result = value.key_value_pairs.get("RESULT").ok_or(())?;
-                    let message = value.key_value_pairs.get("MESSAGE");
+                    let result = parsed_cmd.key_value_pairs.get("RESULT").ok_or(())?;
+                    let message = parsed_cmd.key_value_pairs.get("MESSAGE");
 
                     Ok(Response::Hello {
                         version: Err(I2pError::try_from((*result, message.map(|value| *value)))?),
                     })
                 }
             },
-            ("SESSION", Some("STATUS")) => match value.key_value_pairs.get("DESTINATION") {
+            ("SESSION", Some("STATUS")) => match parsed_cmd.key_value_pairs.get("DESTINATION") {
                 Some(destination) => Ok(Response::Session {
                     destination: Ok(destination.to_string()),
                 }),
                 None => match (
-                    value.key_value_pairs.get("RESULT").ok_or(())?,
-                    value.key_value_pairs.get("ID"),
+                    parsed_cmd.key_value_pairs.get("RESULT").ok_or(())?,
+                    parsed_cmd.key_value_pairs.get("ID"),
                 ) {
                     (&"OK", Some(session_id)) => Ok(Response::Subsession {
                         session_id: Ok(session_id.to_string()),
                     }),
                     (result, _) => {
-                        let message = value.key_value_pairs.get("MESSAGE");
+                        let message = parsed_cmd.key_value_pairs.get("MESSAGE");
 
                         Ok(Response::Session {
                             destination: Err(I2pError::try_from((
@@ -137,10 +137,10 @@ impl<'a> TryFrom<ParsedCommand<'a>> for Response {
                     }
                 },
             },
-            ("STREAM", Some("STATUS")) => match value.key_value_pairs.get("RESULT") {
+            ("STREAM", Some("STATUS")) => match parsed_cmd.key_value_pairs.get("RESULT") {
                 Some(value) if *value == "OK" => Ok(Response::Stream { result: Ok(()) }),
                 Some(error) => {
-                    let message = value.key_value_pairs.get("MESSAGE");
+                    let message = parsed_cmd.key_value_pairs.get("MESSAGE");
 
                     Ok(Response::Stream {
                         result: Err(I2pError::try_from((*error, message.map(|value| *value)))?),
@@ -148,16 +148,17 @@ impl<'a> TryFrom<ParsedCommand<'a>> for Response {
                 }
                 None => return Err(()),
             },
-            ("NAMING", Some("REPLY")) => match value.key_value_pairs.get("RESULT") {
+            ("NAMING", Some("REPLY")) => match parsed_cmd.key_value_pairs.get("RESULT") {
                 Some(result) if *result == "OK" => {
-                    let destination = value.key_value_pairs.get("VALUE").ok_or(())?.to_string();
+                    let destination =
+                        parsed_cmd.key_value_pairs.get("VALUE").ok_or(())?.to_string();
 
                     Ok(Response::NamingLookup {
                         result: Ok(destination),
                     })
                 }
                 Some(error) => {
-                    let message = value.key_value_pairs.get("MESSAGE");
+                    let message = parsed_cmd.key_value_pairs.get("MESSAGE");
 
                     Ok(Response::NamingLookup {
                         result: Err(I2pError::try_from((*error, message.map(|value| *value)))?),
@@ -166,8 +167,8 @@ impl<'a> TryFrom<ParsedCommand<'a>> for Response {
                 None => return Err(()),
             },
             ("DEST", Some("REPLY")) => {
-                let destination = value.key_value_pairs.get("PUB").ok_or(())?.to_string();
-                let private_key = value.key_value_pairs.get("PRIV").ok_or(())?.to_string();
+                let destination = parsed_cmd.key_value_pairs.get("PUB").ok_or(())?.to_string();
+                let private_key = parsed_cmd.key_value_pairs.get("PRIV").ok_or(())?.to_string();
 
                 Ok(Response::DestinationGeneration {
                     destination,

--- a/src/proto/parser.rs
+++ b/src/proto/parser.rs
@@ -184,7 +184,7 @@ impl Response {
     /// Attempt to parse `input` into `Response`.
     //
     // Non-public method returning `IResult` for cleaner error handling.
-    fn parse_inner<'a>(input: &'a str) -> IResult<&'a str, Self> {
+    fn parse_inner(input: &str) -> IResult<&str, Self> {
         let (rest, (command, _, subcommand, _, key_value_pairs)) = tuple((
             alt((
                 tag("HELLO"),

--- a/src/proto/session.rs
+++ b/src/proto/session.rs
@@ -172,38 +172,156 @@ impl SessionController {
                     parameters.style, self.options.nickname
                 );
 
-                for (key, value) in parameters.options {
-                    command += format!("{key}={value} ").as_str();
-                }
+                match parameters.style.as_str() {
+                    "STREAM" => {
+                        for (key, value) in parameters.options {
+                            command += format!("{key}={value} ").as_str();
+                        }
 
-                match &self.options.destination {
-                    DestinationKind::Transient => {
-                        command += "DESTINATION=TRANSIENT ";
+                        match &self.options.destination {
+                            DestinationKind::Transient => {
+                                command += "DESTINATION=TRANSIENT ";
+                            }
+                            DestinationKind::Persistent { private_key } => {
+                                command += format!("DESTINATION={private_key} ").as_str();
+                            }
+                        }
+
+                        if !self.options.i2cp_options.publish_lease_set {
+                            command += "i2cp.dontPublishLeaseSet=true ";
+                        }
+
+                        command += format!(
+                            "inbound.length={} inbound.quantity={} ",
+                            self.options.i2cp_options.inbound_len,
+                            self.options.i2cp_options.inbound_qty
+                        )
+                        .as_str();
+
+                        command += format!(
+                            "outbound.length={} outbound.quantity={} ",
+                            self.options.i2cp_options.outbound_len,
+                            self.options.i2cp_options.outbound_qty
+                        )
+                        .as_str();
+
+                        command += "SIGNATURE_TYPE=7";
+
+                        command += format!(
+                            "i2cp.leaseSetEncType={}\n",
+                            self.options.i2cp_options.lease_set_enc_type
+                        )
+                        .as_str();
+
+                        Ok(command.into_bytes())
                     }
-                    DestinationKind::Persistent { private_key } => {
-                        command += format!("DESTINATION={private_key} ").as_str();
+
+                    "RAW" => {
+                        for (key, value) in parameters.options {
+                            command += format!("{key}={value} ").as_str();
+                        }
+
+                        command += format!(
+                            "PORT={} HOST={} FROM_PORT={} TO_PORT={} PROTOCOL={} HEADER={}",
+                            self.options.datagram_port,
+                            self.options.datagram_host,
+                            self.options.from_port,
+                            self.options.to_port,
+                            self.options.protocol,
+                            self.options.header,
+                        )
+                        .as_str();
+
+                        if !self.options.i2cp_options.publish_lease_set {
+                            command += "i2cp.dontPublishLeaseSet=true ";
+                        }
+
+                        command += format!(
+                            "inbound.length={} inbound.quantity={} ",
+                            self.options.i2cp_options.inbound_len,
+                            self.options.i2cp_options.inbound_qty
+                        )
+                        .as_str();
+
+                        command += format!(
+                            "outbound.length={} outbound.quantity={} ",
+                            self.options.i2cp_options.outbound_len,
+                            self.options.i2cp_options.outbound_qty
+                        )
+                        .as_str();
+
+                        command += "SIGNATURE_TYPE=7";
+
+                        command += format!(
+                            "i2cp.leaseSetEncType={}\n",
+                            self.options.i2cp_options.lease_set_enc_type
+                        )
+                        .as_str();
+
+                        Ok(command.into_bytes())
+                    }
+
+                    "DATAGRAM" => {
+                        for (key, value) in parameters.options {
+                            command += format!("{key}={value} ").as_str();
+                        }
+
+                        match &self.options.destination {
+                            DestinationKind::Transient => {
+                                command += "DESTINATION=TRANSIENT ";
+                            }
+                            DestinationKind::Persistent { private_key } => {
+                                command += format!("DESTINATION={private_key} ").as_str();
+                            }
+                        }
+
+                        command += format!(
+                            "PORT={} HOST={} FROM_PORT={} TO_PORT={}",
+                            self.options.datagram_port,
+                            self.options.datagram_host,
+                            self.options.from_port,
+                            self.options.to_port,
+                        )
+                        .as_str();
+
+                        if !self.options.i2cp_options.publish_lease_set {
+                            command += "i2cp.dontPublishLeaseSet=true ";
+                        }
+
+                        command += format!(
+                            "inbound.length={} inbound.quantity={} ",
+                            self.options.i2cp_options.inbound_len,
+                            self.options.i2cp_options.inbound_qty
+                        )
+                        .as_str();
+
+                        command += format!(
+                            "outbound.length={} outbound.quantity={} ",
+                            self.options.i2cp_options.outbound_len,
+                            self.options.i2cp_options.outbound_qty
+                        )
+                        .as_str();
+
+                        command += "SIGNATURE_TYPE=7";
+
+                        command += format!(
+                            "i2cp.leaseSetEncType={}\n",
+                            self.options.i2cp_options.lease_set_enc_type
+                        )
+                        .as_str();
+
+                        Ok(command.into_bytes())
+                    }
+
+                    _ => {
+                        tracing::warn!(
+                            target: LOG_TARGET,
+                            style = %parameters.style,
+                            "cannot create sessio, non-supported session style",
+                        );
+                        Err(ProtocolError::InvalidMessage)
                     }
                 }
-
-                if !self.options.publish {
-                    command += "i2cp.dontPublishLeaseSet=true ";
-                }
-
-                command += format!(
-                    "inbound.length={} inbound.quantity={} ",
-                    self.options.inbound_len, self.options.num_inbound
-                )
-                .as_str();
-
-                command += format!(
-                    "outbound.length={} outbound.quantity={} ",
-                    self.options.outbound_len, self.options.num_outbound
-                )
-                .as_str();
-
-                command += "SIGNATURE_TYPE=7 i2cp.leaseSetEncType=4\n";
-
-                Ok(command.into_bytes())
             }
             state => {
                 tracing::warn!(
@@ -638,6 +756,7 @@ impl SessionController {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::options::I2CPOptions;
 
     #[test]
     fn open_virtual_stream() {
@@ -808,8 +927,11 @@ mod tests {
     #[test]
     fn dont_publish_lease_set() {
         let mut controller = SessionController::new(SessionOptions {
-            publish: false,
-            ..Default::default()
+            i2cp_options: I2CPOptions {
+                publish_lease_set: false,
+                ..I2CPOptions::default()
+            },
+            ..SessionOptions::default()
         })
         .unwrap();
 

--- a/src/proto/session.rs
+++ b/src/proto/session.rs
@@ -317,7 +317,7 @@ impl SessionController {
                         tracing::warn!(
                             target: LOG_TARGET,
                             style = %parameters.style,
-                            "cannot create sessio, non-supported session style",
+                            "cannot create session, non-supported session style",
                         );
                         Err(ProtocolError::InvalidMessage)
                     }

--- a/src/proto/session.rs
+++ b/src/proto/session.rs
@@ -187,31 +187,25 @@ impl SessionController {
                             }
                         }
 
-                        if !self.options.i2cp_options.publish_lease_set {
+                        if !self.options.publish_lease_set {
                             command += "i2cp.dontPublishLeaseSet=true ";
                         }
 
                         command += format!(
                             "inbound.length={} inbound.quantity={} ",
-                            self.options.i2cp_options.inbound_len,
-                            self.options.i2cp_options.inbound_qty
+                            self.options.inbound_len,
+                            self.options.inbound_qty
                         )
                         .as_str();
 
                         command += format!(
                             "outbound.length={} outbound.quantity={} ",
-                            self.options.i2cp_options.outbound_len,
-                            self.options.i2cp_options.outbound_qty
+                            self.options.outbound_len,
+                            self.options.outbound_qty
                         )
                         .as_str();
 
-                        command += "SIGNATURE_TYPE=7";
-
-                        command += format!(
-                            "i2cp.leaseSetEncType={}\n",
-                            self.options.i2cp_options.lease_set_enc_type
-                        )
-                        .as_str();
+                        command += "SIGNATURE_TYPE=7 i2cp.leaseSetEncType=4\n";
 
                         Ok(command.into_bytes())
                     }
@@ -232,31 +226,25 @@ impl SessionController {
                         )
                         .as_str();
 
-                        if !self.options.i2cp_options.publish_lease_set {
+                        if !self.options.publish_lease_set {
                             command += "i2cp.dontPublishLeaseSet=true ";
                         }
 
                         command += format!(
                             "inbound.length={} inbound.quantity={} ",
-                            self.options.i2cp_options.inbound_len,
-                            self.options.i2cp_options.inbound_qty
+                            self.options.inbound_len,
+                            self.options.inbound_qty
                         )
                         .as_str();
 
                         command += format!(
                             "outbound.length={} outbound.quantity={} ",
-                            self.options.i2cp_options.outbound_len,
-                            self.options.i2cp_options.outbound_qty
+                            self.options.outbound_len,
+                            self.options.outbound_qty
                         )
                         .as_str();
 
-                        command += "SIGNATURE_TYPE=7";
-
-                        command += format!(
-                            "i2cp.leaseSetEncType={}\n",
-                            self.options.i2cp_options.lease_set_enc_type
-                        )
-                        .as_str();
+                        command += "SIGNATURE_TYPE=7 i2cp.leaseSetEncType=4\n";
 
                         Ok(command.into_bytes())
                     }
@@ -284,31 +272,25 @@ impl SessionController {
                         )
                         .as_str();
 
-                        if !self.options.i2cp_options.publish_lease_set {
+                        if !self.options.publish_lease_set {
                             command += "i2cp.dontPublishLeaseSet=true ";
                         }
 
                         command += format!(
                             "inbound.length={} inbound.quantity={} ",
-                            self.options.i2cp_options.inbound_len,
-                            self.options.i2cp_options.inbound_qty
+                            self.options.inbound_len,
+                            self.options.inbound_qty
                         )
                         .as_str();
 
                         command += format!(
                             "outbound.length={} outbound.quantity={} ",
-                            self.options.i2cp_options.outbound_len,
-                            self.options.i2cp_options.outbound_qty
+                            self.options.outbound_len,
+                            self.options.outbound_qty
                         )
                         .as_str();
 
-                        command += "SIGNATURE_TYPE=7";
-
-                        command += format!(
-                            "i2cp.leaseSetEncType={}\n",
-                            self.options.i2cp_options.lease_set_enc_type
-                        )
-                        .as_str();
+                        command += "SIGNATURE_TYPE=7 i2cp.leaseSetEncType=4\n";
 
                         Ok(command.into_bytes())
                     }
@@ -756,7 +738,6 @@ impl SessionController {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::options::I2CPOptions;
 
     #[test]
     fn open_virtual_stream() {
@@ -927,11 +908,8 @@ mod tests {
     #[test]
     fn dont_publish_lease_set() {
         let mut controller = SessionController::new(SessionOptions {
-            i2cp_options: I2CPOptions {
-                publish_lease_set: false,
-                ..I2CPOptions::default()
-            },
-            ..SessionOptions::default()
+            publish_lease_set: false,
+            ..Default::default()
         })
         .unwrap();
 

--- a/src/proto/session.rs
+++ b/src/proto/session.rs
@@ -187,24 +187,19 @@ impl SessionController {
 
                 match parameters.style.as_str() {
                     "PRIMARY" => {}
-
                     "STREAM" => {}
-
                     "DATAGRAM" => {
                         command += format!(
-                            "FROM_PORT={} TO_PORT={}",
+                            "FROM_PORT={} TO_PORT={} ",
                             self.options.from_port, self.options.to_port,
                         )
                         .as_str();
                     }
-
                     "DATAGRAM2" => {}
-
                     "DATAGRAM3" => {}
-
                     "RAW" => {
                         command += format!(
-                            "FROM_PORT={} TO_PORT={} PROTOCOL={} HEADER={}",
+                            "FROM_PORT={} TO_PORT={} PROTOCOL={} HEADER={} ",
                             self.options.from_port,
                             self.options.to_port,
                             self.options.protocol,
@@ -212,7 +207,6 @@ impl SessionController {
                         )
                         .as_str();
                     }
-
                     _ => {
                         tracing::warn!(
                             target: LOG_TARGET,

--- a/src/proto/session.rs
+++ b/src/proto/session.rs
@@ -217,7 +217,7 @@ impl SessionController {
                     }
                 }
 
-                if !self.options.publish_lease_set {
+                if !self.options.publish {
                     command += "i2cp.dontPublishLeaseSet=true ";
                 }
 
@@ -838,7 +838,7 @@ mod tests {
     #[test]
     fn dont_publish_lease_set() {
         let mut controller = SessionController::new(SessionOptions {
-            publish_lease_set: false,
+            publish: false,
             ..Default::default()
         })
         .unwrap();


### PR DESCRIPTION
An humble proposal to resolve issue #10, adding as a bonus (most of the) i2cp options alongside the datagram ones, in case the former become needed in the future.