### PR TITLE
Introduce DatagramOptions

### DIFF
--- a/src/asynchronous/session/mod.rs
+++ b/src/asynchronous/session/mod.rs
@@ -28,7 +28,7 @@ use crate::{
         stream::Stream,
     },
     error::Error,
-    options::{SessionOptions, StreamOptions},
+    options::{DatagramOptions, SessionOptions, StreamOptions},
     proto::session::SessionController,
 };
 
@@ -51,7 +51,7 @@ pub mod style;
 /// Each session style enables a set of APIs that can be used to interact with remote destinations
 /// over that protocol.
 ///
-/// Primary sessions allows creating sub-sessions and interacting with remote destinations over
+/// Primary sessions allow creating sub-sessions and interacting with remote destinations over
 /// different protocols using the same destination and tunnel pool.
 ///
 /// ### Virtual streams
@@ -103,6 +103,27 @@ pub mod style;
 /// }
 /// ```
 ///
+/// Some of the options of the repliable session can be overriden on a per datagram basis.
+///
+/// ```no_run
+/// use yosemite::{RouterApi, Session, style::Repliable, options::DatagramOptions};
+///
+/// #[tokio::main]
+/// async fn main() -> yosemite::Result<()> {
+///     let mut session = Session::<Repliable>::new(Default::default()).await?;
+///     let mut buffer = vec![0u8; 64];
+///     let destination = RouterApi::default().lookup_name("datagram_server.i2p").await?;
+///     let datagram_options = DatagramOptions { from_port: 1u16, to_port: 1u16, protocol: 18u8, send_tags: 20usize,
+///            tag_threshold: 20usize,
+///            send_leaseset: false,
+///             };
+///
+///         session.send_to_with_options(&mut buffer, &destination, datagram_options).await?;
+///
+///     Ok(())
+/// }
+/// ```
+///
 /// ### Anonymous datagrams
 ///
 /// The anonymous datagram API allow sending raw datagrams to remote destination. The destination of
@@ -120,6 +141,26 @@ pub mod style;
 ///     for i in 0..5 {
 ///         session.send_to(&[i as u8; 64], &destination).await?;
 ///     }
+///
+///     Ok(())
+/// }
+/// ```
+/// Some of the options of the anonymous session can be overriden on a per datagram basis.
+///
+/// ```no_run
+/// use yosemite::{RouterApi, Session, style::Anonymous, options::DatagramOptions};
+///
+/// #[tokio::main]
+/// async fn main() -> yosemite::Result<()> {
+///     let mut session = Session::<Anonymous>::new(Default::default()).await?;
+///     let mut buffer = vec![0u8; 64];
+///     let destination = RouterApi::default().lookup_name("datagram_server.i2p").await?;
+///     let datagram_options = DatagramOptions { from_port: 1u16, to_port: 1u16, protocol: 17u8, send_tags: 20usize,
+///            tag_threshold: 20usize,
+///            send_leaseset: false,
+///             };
+///
+///         session.send_to_with_options(&mut buffer, &destination, datagram_options).await?;
 ///
 ///     Ok(())
 /// }
@@ -378,6 +419,16 @@ impl Session<style::Repliable> {
         style::Repliable::send_to(&mut self.context, buf, destination).await
     }
 
+    /// Send data on the socket to given `destination` and overrides some of the session options
+    pub async fn send_to_with_options(
+        &mut self,
+        buf: &[u8],
+        destination: &str,
+        options: DatagramOptions,
+    ) -> crate::Result<()> {
+        style::Repliable::send_to_with_options(&mut self.context, buf, destination, options).await
+    }
+
     /// Receive a single datagram on the socket.
     ///
     /// `buf` must be of sufficient size to hold the entire datagram.
@@ -392,6 +443,16 @@ impl Session<style::Anonymous> {
     /// Send data on the socket to given `destination`.
     pub async fn send_to(&mut self, buf: &[u8], destination: &str) -> crate::Result<()> {
         style::Anonymous::send_to(&mut self.context, buf, destination).await
+    }
+
+    /// Send data on the socket to given `destination` and overrides some of the session options
+    pub async fn send_to_with_options(
+        &mut self,
+        buf: &[u8],
+        destination: &str,
+        options: DatagramOptions,
+    ) -> crate::Result<()> {
+        style::Anonymous::send_to_with_options(&mut self.context, buf, destination, options).await
     }
 
     /// Receive a single datagram on the socket.

--- a/src/asynchronous/session/mod.rs
+++ b/src/asynchronous/session/mod.rs
@@ -103,27 +103,6 @@ pub mod style;
 /// }
 /// ```
 ///
-/// Some of the options of the repliable session can be overriden on a per datagram basis.
-///
-/// ```no_run
-/// use yosemite::{RouterApi, Session, style::Repliable, options::DatagramOptions};
-///
-/// #[tokio::main]
-/// async fn main() -> yosemite::Result<()> {
-///     let mut session = Session::<Repliable>::new(Default::default()).await?;
-///     let mut buffer = vec![0u8; 64];
-///     let destination = RouterApi::default().lookup_name("datagram_server.i2p").await?;
-///     let datagram_options = DatagramOptions { from_port: 1u16, to_port: 1u16, protocol: 18u8, send_tags: 20usize,
-///            tag_threshold: 20usize,
-///            send_leaseset: false,
-///             };
-///
-///         session.send_to_with_options(&mut buffer, &destination, datagram_options).await?;
-///
-///     Ok(())
-/// }
-/// ```
-///
 /// ### Anonymous datagrams
 ///
 /// The anonymous datagram API allow sending raw datagrams to remote destination. The destination of
@@ -141,26 +120,6 @@ pub mod style;
 ///     for i in 0..5 {
 ///         session.send_to(&[i as u8; 64], &destination).await?;
 ///     }
-///
-///     Ok(())
-/// }
-/// ```
-/// Some of the options of the anonymous session can be overriden on a per datagram basis.
-///
-/// ```no_run
-/// use yosemite::{RouterApi, Session, style::Anonymous, options::DatagramOptions};
-///
-/// #[tokio::main]
-/// async fn main() -> yosemite::Result<()> {
-///     let mut session = Session::<Anonymous>::new(Default::default()).await?;
-///     let mut buffer = vec![0u8; 64];
-///     let destination = RouterApi::default().lookup_name("datagram_server.i2p").await?;
-///     let datagram_options = DatagramOptions { from_port: 1u16, to_port: 1u16, protocol: 17u8, send_tags: 20usize,
-///            tag_threshold: 20usize,
-///            send_leaseset: false,
-///             };
-///
-///         session.send_to_with_options(&mut buffer, &destination, datagram_options).await?;
 ///
 ///     Ok(())
 /// }

--- a/src/asynchronous/session/style/datagram.rs
+++ b/src/asynchronous/session/style/datagram.rs
@@ -85,7 +85,7 @@ impl Repliable {
             options.to_port,
             options.send_tags,
             options.tag_threshold,
-            options.send_leaseset,
+            options.send_lease_set,
         )
         .as_bytes()
         .to_vec();
@@ -249,7 +249,7 @@ impl Anonymous {
             options.protocol,
             options.send_tags,
             options.tag_threshold,
-            options.send_leaseset,
+            options.send_lease_set,
         )
         .as_bytes()
         .to_vec();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ mod options;
 mod proto;
 
 pub use error::{Error, I2pError, ProtocolError};
-pub use options::{DestinationKind, SessionOptions, StreamOptions};
+pub use options::{DatagramOptions, DestinationKind, SessionOptions, StreamOptions};
 
 #[cfg(any(feature = "tokio", feature = "smol"))]
 mod asynchronous;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ compile_error!("feature \"sync\" and feature \"tokio\" cannot be enabled at the 
 compile_error!("feature \"sync\" and feature \"smol\" cannot be enabled at the same time");
 
 mod error;
-pub mod options;
+mod options;
 mod proto;
 
 pub use error::{Error, I2pError, ProtocolError};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ compile_error!("feature \"sync\" and feature \"tokio\" cannot be enabled at the 
 compile_error!("feature \"sync\" and feature \"smol\" cannot be enabled at the same time");
 
 mod error;
-mod options;
+pub mod options;
 mod proto;
 
 pub use error::{Error, I2pError, ProtocolError};

--- a/src/options.rs
+++ b/src/options.rs
@@ -84,7 +84,7 @@ pub struct SessionOptions {
     /// Defaults to `0`.
     pub to_port: u16,
 
-    /// Defaults to `18`.
+    /// Defaults to `18`, i.e., raw datagrams
     pub protocol: u8,
 
     /// Defaults to `false`.
@@ -397,4 +397,27 @@ pub struct StreamOptions {
     ///
     /// Defaults to `0`.
     pub src_port: u16,
+}
+
+#[derive(Default)]
+pub struct DatagramOptions {
+    /// Overrides the source port
+    pub from_port: u16,
+
+    /// Overrides the destination port
+    pub to_port: u16,
+
+    /// Overrides the I2P protocol used
+    ///
+    /// Only for RAW/Anonymous sessions
+    pub protocol: u8,
+
+    /// Overrides the crypto_tags_to_send I2CP option
+    pub send_tags: usize,
+
+    /// Overrides the crypto_low_tag_threshold I2CP option
+    pub tag_threshold: usize,
+
+    /// Overrides the should_bundle_reply_info I2CP option
+    pub send_leaseset: bool,
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -401,23 +401,35 @@ pub struct StreamOptions {
 
 #[derive(Default)]
 pub struct DatagramOptions {
-    /// Overrides the source port
+    /// Overrides the source port.
+    ///
+    /// Defaults to `0`.
     pub from_port: u16,
 
-    /// Overrides the destination port
+    /// Overrides the destination port.
+    ///
+    /// Defaults to `0`.
     pub to_port: u16,
 
-    /// Overrides the I2P protocol used
+    /// Overrides the I2P protocol used.
     ///
-    /// Only for RAW/Anonymous sessions
+    /// Only for RAW/Anonymous sessions.
+    ///
+    /// Defaults to `18`.
     pub protocol: u8,
 
-    /// Overrides the crypto_tags_to_send I2CP option
+    /// Overrides the [`SessionOptions::crypto_tags_to_send`] I2CP option.
+    ///
+    /// Defaults to `0`.
     pub send_tags: usize,
 
-    /// Overrides the crypto_low_tag_threshold I2CP option
+    /// Overrides the [`SessionOptions::crypto_low_tag_threshold`] I2CP option.
+    ///
+    /// Defaults to `0`.
     pub tag_threshold: usize,
 
-    /// Overrides the should_bundle_reply_info I2CP option
-    pub send_leaseset: bool,
+    /// Overrides the [`SessionOptions::should_bundle_reply_info`] I2CP option.
+    ///
+    /// Defaults to `true`.
+    pub send_lease_set: bool,
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -399,6 +399,7 @@ pub struct StreamOptions {
     pub src_port: u16,
 }
 
+/// Datagram options.
 #[derive(Default)]
 pub struct DatagramOptions {
     /// Overrides the source port.

--- a/src/synchronous/session/mod.rs
+++ b/src/synchronous/session/mod.rs
@@ -20,7 +20,7 @@
 
 use crate::{
     error::Error,
-    options::{SessionOptions, StreamOptions},
+    options::{DatagramOptions, SessionOptions, StreamOptions},
     proto::session::SessionController,
     style::{
         private::{SessionStyle as SealedSessionStyle, Subsession as SealedSubsession},
@@ -287,6 +287,16 @@ impl Session<style::Repliable> {
         style::Repliable::send_to(&mut self.context, buf, destination)
     }
 
+    /// Send data on the socket to given `destination` and overrides some of the session options
+    pub fn send_to_with_options(
+        &mut self,
+        buf: &[u8],
+        destination: &str,
+        options: DatagramOptions,
+    ) -> crate::Result<()> {
+        style::Repliable::send_to_with_options(&mut self.context, buf, destination, options)
+    }
+
     /// Receive a single datagram on the socket.
     ///
     /// `buf` must be of sufficient size to hold the entire datagram.
@@ -301,6 +311,16 @@ impl Session<style::Anonymous> {
     /// Send data on the socket to given `destination`.
     pub fn send_to(&mut self, buf: &[u8], destination: &str) -> crate::Result<()> {
         style::Anonymous::send_to(&mut self.context, buf, destination)
+    }
+
+    /// Send data on the socket to given `destination` and overrides some of the session options
+    pub fn send_to_with_options(
+        &mut self,
+        buf: &[u8],
+        destination: &str,
+        options: DatagramOptions,
+    ) -> crate::Result<()> {
+        style::Anonymous::send_to_with_options(&mut self.context, buf, destination, options)
     }
 
     /// Receive a single datagram on the socket.

--- a/src/synchronous/session/style/datagram.rs
+++ b/src/synchronous/session/style/datagram.rs
@@ -19,7 +19,7 @@
 #![cfg(all(feature = "sync", not(any(feature = "tokio", feature = "smol"))))]
 
 use crate::{
-    options::SessionOptions,
+    options::{DatagramOptions, SessionOptions},
     style::{private, SessionStyle, Subsession},
     Error,
 };
@@ -53,6 +53,32 @@ impl Repliable {
     pub(crate) fn send_to(&mut self, buf: &[u8], destination: &str) -> crate::Result<()> {
         let mut datagram =
             format!("3.0 {} {}\n", self.options.nickname, destination).as_bytes().to_vec();
+        datagram.extend_from_slice(buf);
+
+        self.socket
+            .send_to(&datagram, &self.server_address)
+            .map(|_| ())
+            .map_err(From::from)
+    }
+
+    pub(crate) fn send_to_with_options(
+        &mut self,
+        buf: &[u8],
+        destination: &str,
+        options: DatagramOptions,
+    ) -> crate::Result<()> {
+        let mut datagram = format!(
+            "3.0 {} {} {} {} {} {} {}\n",
+            self.options.nickname,
+            destination,
+            options.from_port,
+            options.to_port,
+            options.send_tags,
+            options.tag_threshold,
+            options.send_leaseset,
+        )
+        .as_bytes()
+        .to_vec();
         datagram.extend_from_slice(buf);
 
         self.socket
@@ -180,6 +206,33 @@ impl Anonymous {
     pub(crate) fn send_to(&mut self, buf: &[u8], destination: &str) -> crate::Result<()> {
         let mut datagram =
             format!("3.0 {} {}\n", self.options.nickname, destination).as_bytes().to_vec();
+        datagram.extend_from_slice(buf);
+
+        self.socket
+            .send_to(&datagram, &self.server_address)
+            .map(|_| ())
+            .map_err(From::from)
+    }
+
+    pub(crate) fn send_to_with_options(
+        &mut self,
+        buf: &[u8],
+        destination: &str,
+        options: DatagramOptions,
+    ) -> crate::Result<()> {
+        let mut datagram = format!(
+            "3.0 {} {} {} {} {} {} {} {}\n",
+            self.options.nickname,
+            destination,
+            options.from_port,
+            options.to_port,
+            options.protocol,
+            options.send_tags,
+            options.tag_threshold,
+            options.send_leaseset,
+        )
+        .as_bytes()
+        .to_vec();
         datagram.extend_from_slice(buf);
 
         self.socket

--- a/src/synchronous/session/style/datagram.rs
+++ b/src/synchronous/session/style/datagram.rs
@@ -75,7 +75,7 @@ impl Repliable {
             options.to_port,
             options.send_tags,
             options.tag_threshold,
-            options.send_leaseset,
+            options.send_lease_set,
         )
         .as_bytes()
         .to_vec();
@@ -229,7 +229,7 @@ impl Anonymous {
             options.protocol,
             options.send_tags,
             options.tag_threshold,
-            options.send_leaseset,
+            options.send_lease_set,
         )
         .as_bytes()
         .to_vec();


### PR DESCRIPTION
Aims at closing #9 

I wrote 2 new doctests for the asynchronous module, but I had to set the root options.rs file to public in order to use `DatagramOptions`.
Is it an issue ?

Feel free to tear those doctests if so.